### PR TITLE
[WIP] export pydd waveforms to pycbc using the plugin protocol 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,11 @@ install_requires =
     scipy
     jax
     jaxlib
+    jaxinterp2d @ git+https://github.com/adam-coogan/jaxinterp2d#egg=jaxinterp2d
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+pycbc.waveform.td =
+    pydd = pydd.plugin:pydd_td_strain

--- a/src/pydd/plugin.py
+++ b/src/pydd/plugin.py
@@ -1,0 +1,79 @@
+""" Exporting the PyCBC plugin interface for the PyDD waveforms
+"""
+
+
+def pydd_td_strain(**params):
+    """Generate the GW polarizations in PyCBC types"""
+
+    from pycbc.types import TimeSeries
+    import numpy as np
+    from scipy.interpolate import interp1d
+    from math import pi
+    from pydd.binary import t_to_c, make_vacuum_binary, make_dynamic_dress
+
+    # SI units
+    G = 6.67408e-11  # m^3 s^-2 kg^-1
+    C = 299792458.0  # m/s
+    MSUN = 1.98855e30  # kg
+    PC = 3.08567758149137e16  # m
+
+    m_1 = params['mass1'] * MSUN
+    m_2 = params['mass2'] * MSUN
+    iota = params['inclination']
+    d_l = params['distance'] * PC * 1e6
+    system = params['system']
+    dt = params['delta_t']
+    phi_c = params['coa_phase']
+    f_lower = params['f_lower']
+
+    if (system == "vacuum"):
+        dd = make_vacuum_binary(m_1, m_2)
+    else:
+        gamma = 9./4.
+        rho = 1.396e13*(m_1/MSUN)**(3/4)
+        rho *= MSUN/PC**3
+        dd = make_dynamic_dress(m_1, m_2, rho, gamma)
+
+    if 'f_final' in params and params['f_final'] > params['f_lower']:
+        f_final = params['f_final']
+    else:
+        f_final = dd.f_c
+
+    _fs = np.geomspace(f_lower, f_final, 10000)
+    _ts = t_to_c(_fs, dd)
+    _ts *= -1  # time to merger
+
+    t_merge = t_to_c(f_lower, dd)
+    t_stop = t_to_c(dd.f_c, dd)
+    t_obs = t_merge - t_stop
+    ts = np.arange(t_stop - t_obs, t_stop, dt)
+
+    _omega_gws = 2 * pi * _fs
+    omega_gw = interp1d(_ts, _omega_gws)
+
+    _omega_orbs = 2 * pi * (_fs / 2)
+    omega_orb = interp1d(_ts, _omega_orbs)
+    _rs = (G * (m_1 + m_2) / (pi * _fs) ** 2) ** (1 / 3)
+    r = interp1d(_ts, _rs)
+
+    def h0(t):
+        return 4 * G * m_2 * omega_orb(t) ** 2 * r(t) ** 2 / C ** 4
+
+    def hp_t(t, d_l, iota, phi_c=0):
+        return (
+            1
+            / d_l
+            * h0(t)
+            * (1 + np.cos(iota) ** 2)
+            / 2
+            * np.cos(omega_gw(t) * t + phi_c)
+        )
+
+    def hc_t(t, d_l, iota, phi_c=0):
+        return 1 / d_l * h0(t) * np.cos(iota) * np.sin(omega_gw(t) * t + phi_c)
+
+    hp_ts = hp_t(ts, d_l, iota, phi_c)
+    hc_ts = hc_t(ts, d_l, iota, phi_c)
+
+    return (TimeSeries(hp_ts, delta_t=dt, epoch=float(-t_merge)),
+           TimeSeries(hp_ts, delta_t=dt, epoch=float(-t_merge)))


### PR DESCRIPTION
I attempted to adapt the https://github.com/adam-coogan/pydd/blob/main/scripts/load_strains_approx.py script in the repo so that one can generate the plus / cross polarizations of the dark dress waveform model easily. 

This PR adds in a 'plugin' module which provides the common pycbc waveform generation interface (for td waveforms atm, we could add the interface for fourier domain later also here). This means that when pydd is installed, the waveform models automatically are found by pycbc and can be used within the common interfaces, routines, and programs. Once working, this will allow people to use the PyDD waveform within PE, searches, and create mock data using the model for further study. 

Note, that at the moment, there appears to be some convention issue. As I am unable to reproduce the expected waveform behavior in the vacuum waveform limit. I've compared to the TaylorF2 approximant and the phasing / overlap is quite different. It's almost as if the mass scale were incorrect. It's possible that when adapting the script above, I have made a mistake, but if the pydd experts quickly spot the issue, please let me know. 

The issue can be seen by running the following if both pydd and pycbc are installed. 

```
from pycbc.waveform import get_td_waveform
from matplotlib import pyplot as plt

common = dict(mass1=1.0, mass2=1.0,
              f_lower=20.0,
              delta_t=1.0/4096)

hp, hc = get_td_waveform(approximant='pydd', system='vacuum', **common)
hp2, hc2 = get_td_waveform(approximant='TaylorF2', **common)

plt.figure(dpi=200)
hp.plot(label='pydd')
hp2.plot(label='TF2')
plt.xlim(-1.0, 0)
plt.legend()
```
![download - 2022-07-31T133552 355](https://user-images.githubusercontent.com/2206534/182038578-e556f532-8e44-4002-96e2-f281dc36fc0e.png)

